### PR TITLE
made media query smaller for ONLY the snowman

### DIFF
--- a/public/stylesheets/reset.css
+++ b/public/stylesheets/reset.css
@@ -695,10 +695,7 @@ img {
   .answers-content {
     display: block;
   }
-  #navTitle {
-    content: url(../knick-knack-title.png);
-    width: 80px;
-  }
+
   .question-card {
     width: 90vw;
   }
@@ -732,6 +729,16 @@ img {
     list-style-type: none;
     justify-content: flex-start;
     align-content: flex-start;
+  }
+}
+
+@media (max-width: 800px) {
+  .answers-content {
+    display: block;
+  }
+  #navTitle {
+    content: url(../knick-knack-title.png);
+    width: 80px;
   }
 }
 


### PR DESCRIPTION
made a small stylistic change so that the "knick knack overflow" header on the navBar turns into the snowman logo at 900 px vs 1200 px, to eliminate whitespace.